### PR TITLE
core: add android application convention plugin

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,39 +1,15 @@
 plugins {
-    alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.habits.android.application)
     alias(libs.plugins.kotlin.compose)
 }
 
 android {
     namespace = "com.roblesdotdev.habitsapp"
-    compileSdk = 35
 
     defaultConfig {
-        applicationId = "com.roblesdotdev.habitsapp"
-        minSdk = 24
-        targetSdk = 35
-        versionCode = 1
-        versionName = "1.0"
-
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
-            )
-        }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
-    }
-    kotlinOptions {
-        jvmTarget = "11"
-    }
     buildFeatures {
         compose = true
     }

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -10,3 +10,12 @@ dependencies {
     compileOnly(libs.ksp.gradlePlugin)
     compileOnly(libs.room.gradlePlugin)
 }
+
+gradlePlugin {
+    plugins {
+        register("androidApplication") {
+            id = "habits.android.application"
+            implementationClass = "AndroidApplicationConventionPlugin"
+        }
+    }
+}

--- a/build-logic/convention/src/main/java/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/java/AndroidApplicationConventionPlugin.kt
@@ -1,0 +1,35 @@
+import com.android.build.api.dsl.ApplicationExtension
+import com.roblesdotdev.convention.ExtensionType
+import com.roblesdotdev.convention.configureBuildTypes
+import com.roblesdotdev.convention.configureKotlinAndroid
+import com.roblesdotdev.convention.libs
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+
+class AndroidApplicationConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        target.run {
+            pluginManager.run {
+                apply("com.android.application")
+                apply("org.jetbrains.kotlin.android")
+            }
+
+            extensions.configure<ApplicationExtension> {
+                defaultConfig {
+                    applicationId = libs.findVersion("projectApplicationId").get().toString()
+                    targetSdk = libs.findVersion("projectTargetSdkVersion").get().toString().toInt()
+                    versionCode = libs.findVersion("projectVersionCode").get().toString().toInt()
+                    versionName = libs.findVersion("projectVersionName").get().toString()
+                }
+
+                configureKotlinAndroid(this)
+
+                configureBuildTypes(
+                    commonExtension = this,
+                    extensionType = ExtensionType.APPLICATION
+                )
+            }
+        }
+    }
+}

--- a/build-logic/convention/src/main/java/com/roblesdotdev/convention/BuildTypes.kt
+++ b/build-logic/convention/src/main/java/com/roblesdotdev/convention/BuildTypes.kt
@@ -1,0 +1,63 @@
+package com.roblesdotdev.convention
+
+import com.android.build.api.dsl.ApplicationExtension
+import com.android.build.api.dsl.BuildType
+import com.android.build.api.dsl.CommonExtension
+import com.android.build.api.dsl.LibraryExtension
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+
+internal fun Project.configureBuildTypes(
+    commonExtension: CommonExtension<*, *, *, *, *, *>,
+    extensionType: ExtensionType,
+) {
+    commonExtension.run {
+        buildFeatures {
+            buildConfig = true
+        }
+    }
+
+    when (extensionType) {
+        ExtensionType.APPLICATION -> {
+            extensions.configure<ApplicationExtension> {
+                buildTypes {
+                    debug {
+                        configureDebugBuildType()
+                    }
+                    release {
+                        configureReleaseBuildType(commonExtension = commonExtension)
+                    }
+                }
+            }
+        }
+        ExtensionType.LIBRARY -> {
+            extensions.configure<LibraryExtension> {
+                buildTypes {
+                    debug {
+                        configureDebugBuildType()
+                    }
+                    release {
+                        configureReleaseBuildType(commonExtension = commonExtension)
+                    }
+                }
+
+            }
+        }
+    }
+}
+
+private fun BuildType.configureDebugBuildType() {
+    buildConfigField(type = "String", name = "BASE_URL", value = "\"localhost:3000\"")
+}
+
+private fun BuildType.configureReleaseBuildType(
+    commonExtension: CommonExtension<*, *, *, *, *, *>,
+) {
+    buildConfigField(type = "String", name = "BASE_URL", value = "\"localhost:3000\"")
+
+    isMinifyEnabled = true
+    proguardFiles(
+        commonExtension.getDefaultProguardFile("proguard-android-optimize.txt"),
+        "proguard-rules.pro"
+    )
+}

--- a/build-logic/convention/src/main/java/com/roblesdotdev/convention/ExtensionType.kt
+++ b/build-logic/convention/src/main/java/com/roblesdotdev/convention/ExtensionType.kt
@@ -1,0 +1,6 @@
+package com.roblesdotdev.convention
+
+enum class ExtensionType {
+    APPLICATION,
+    LIBRARY,
+}

--- a/build-logic/convention/src/main/java/com/roblesdotdev/convention/Kotlin.kt
+++ b/build-logic/convention/src/main/java/com/roblesdotdev/convention/Kotlin.kt
@@ -1,0 +1,41 @@
+package com.roblesdotdev.convention
+
+import com.android.build.api.dsl.CommonExtension
+import org.gradle.api.JavaVersion
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.dependencies
+import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+internal fun Project.configureKotlinAndroid(
+    commonExtension: CommonExtension<*, *, *, *, *, *>
+) {
+    commonExtension.apply {
+        compileSdk = libs.findVersion("projectCompileSdkVersion").get().toString().toInt()
+
+        defaultConfig {
+            minSdk = libs.findVersion("projectMinSdkVersion").get().toString().toInt()
+        }
+
+        compileOptions {
+            isCoreLibraryDesugaringEnabled = true
+            sourceCompatibility = JavaVersion.VERSION_17
+            targetCompatibility = JavaVersion.VERSION_17
+        }
+    }
+
+    configureKotlin()
+
+    dependencies {
+        "coreLibraryDesugaring"(libs.findLibrary("desugar-jdk-libs").get())
+    }
+}
+
+private fun Project.configureKotlin() {
+    tasks.withType<KotlinCompile>().configureEach {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_17)
+        }
+    }
+}

--- a/build-logic/convention/src/main/java/com/roblesdotdev/convention/MyClass.kt
+++ b/build-logic/convention/src/main/java/com/roblesdotdev/convention/MyClass.kt
@@ -1,4 +1,0 @@
-package com.roblesdotdev.convention
-
-class MyClass {
-}

--- a/build-logic/convention/src/main/java/com/roblesdotdev/convention/ProjectExt.kt
+++ b/build-logic/convention/src/main/java/com/roblesdotdev/convention/ProjectExt.kt
@@ -1,0 +1,9 @@
+package com.roblesdotdev.convention
+
+import org.gradle.api.Project
+import org.gradle.api.artifacts.VersionCatalog
+import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.kotlin.dsl.getByType
+
+val Project.libs: VersionCatalog
+    get() = extensions.getByType<VersionCatalogsExtension>().named("libs")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,8 +20,14 @@ dataStore = "1.1.7"
 retrofit = "3.0.0"
 workManager = "2.10.1"
 desugar = "2.1.5"
-appcompat = "1.7.1"
-material = "1.12.0"
+
+# Project config
+projectVersionName = "1.0"
+projectApplicationId = "com.roblesdotdev.habits"
+projectMinSdkVersion = "24"
+projectCompileSdkVersion = "35"
+projectTargetSdkVersion = "35"
+projectVersionCode = "1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -55,8 +61,6 @@ androidx-datastore-preferences-core = { module = "androidx.datastore:datastore-p
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
 retrofit-converter-moshi = { module = "com.squareup.retrofit2:converter-moshi", version.ref = "retrofit" }
 androidx-work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "workManager" }
-androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
-material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 
 # complileOnly
 android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }
@@ -74,3 +78,6 @@ google-devtools-ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 androidx-room = { id = "androidx.room", version.ref = "room" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref ="hilt" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+
+# Convention plugins
+habits-android-application = { id = "habits.android.application", version = "unespecified" }


### PR DESCRIPTION
This PR introduces a convention plugin for Android application modules. The goal is to centralize and standardize common configuration across modules, reducing duplication and improving maintainability.

**Automatically applies the following plugins:**

- `com.android.application`
- `org.jetbrains.kotlin.android`

**Configures defaultConfig using values from libs.versions.toml, including:**

- `applicationId`
- `targetSdk`
- `versionCode`
- `versionName`

**Kotlin and Java configuration:**

- Sets compileSdk and minSdk
- Enables core library desugaring
- Uses Java 17 compatibility
- Sets Kotlin jvmTarget to 17

**Add configuration function for defining buildTypes (debug and release) across both application and library modules.**

- Supports both application and library modules via ExtensionType enum.
- Defines common buildTypes: `debug` & `release`
- Ensures buildConfig generation is enabled via buildFeatures.