### PR TITLE
core: android application compose convention plugin

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
-    alias(libs.plugins.habits.android.application)
-    alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.habits.android.application.compose)
 }
 
 android {
@@ -9,25 +8,25 @@ android {
     defaultConfig {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
-
-    buildFeatures {
-        compose = true
-    }
 }
 
 dependencies {
+    // Core
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
+
+    // Compose
     implementation(libs.androidx.activity.compose)
-    implementation(platform(libs.androidx.compose.bom))
+    implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.compose.ui)
     implementation(libs.androidx.compose.ui.graphics)
     implementation(libs.androidx.compose.ui.tooling.preview)
-    implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.lifecycle.viewmodel.compose)
+    implementation(libs.androidx.lifecycle.runtime.compose)
+
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
-    androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.androidx.compose.ui.test.junit4)
     debugImplementation(libs.androidx.compose.ui.tooling)
     debugImplementation(libs.androidx.compose.ui.test.manifest)

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -17,5 +17,9 @@ gradlePlugin {
             id = "habits.android.application"
             implementationClass = "AndroidApplicationConventionPlugin"
         }
+        register("androidApplicationCompose") {
+            id = "habits.android.application.compose"
+            implementationClass = "AndroidApplicationComposeConventionPlugin"
+        }
     }
 }

--- a/build-logic/convention/src/main/java/AndroidApplicationComposeConventionPlugin.kt
+++ b/build-logic/convention/src/main/java/AndroidApplicationComposeConventionPlugin.kt
@@ -1,0 +1,18 @@
+import com.android.build.api.dsl.ApplicationExtension
+import com.roblesdotdev.convention.configureAndroidCompose
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.getByType
+
+class AndroidApplicationComposeConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        target.run {
+            pluginManager.apply("habits.android.application")
+            pluginManager.apply("org.jetbrains.kotlin.plugin.compose")
+
+            val extension = extensions.getByType<ApplicationExtension>()
+            configureAndroidCompose(extension)
+        }
+    }
+
+}

--- a/build-logic/convention/src/main/java/com/roblesdotdev/convention/AndroidCompose.kt
+++ b/build-logic/convention/src/main/java/com/roblesdotdev/convention/AndroidCompose.kt
@@ -1,0 +1,22 @@
+package com.roblesdotdev.convention
+
+import com.android.build.api.dsl.CommonExtension
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.dependencies
+
+internal fun Project.configureAndroidCompose(
+    commonExtension: CommonExtension<*, *, *, *, *, *>
+) {
+    commonExtension.run {
+        buildFeatures {
+            compose = true
+        }
+
+        dependencies {
+            val bom = libs.findLibrary("androidx.compose.bom").get()
+            "implementation"(platform(bom))
+            "androidTestImplementation"(platform(bom))
+            "debugImplementation"(libs.findLibrary("androidx.compose.ui.tooling.preview").get())
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -81,3 +81,4 @@ kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", versi
 
 # Convention plugins
 habits-android-application = { id = "habits.android.application", version = "unespecified" }
+habits-android-application-compose = { id = "habits.android.application.compose", version = "unespecified" }


### PR DESCRIPTION
This PR introduces a dedicated convention plugin for Android applications that use Jetpack Compose, building on top of the base application convention.

- Applies:
  - `habits.android.application` (custom base application convention)
  - `org.jetbrains.kotlin.plugin.compose`
- Enables Jetpack Compose support via `buildFeatures.compose = true`
- Adds Compose dependencies:
  - Uses the Compose BOM for version alignment.
  - Adds tooling support for Preview in debugImplementation.
  - Ensures Compose libraries are available in both implementation and androidTestImplementation.