### PR TITLE
core: add jvm library convention plugin

### DIFF
--- a/auth/domain/build.gradle.kts
+++ b/auth/domain/build.gradle.kts
@@ -1,15 +1,5 @@
 plugins {
-    id("java-library")
-    alias(libs.plugins.jetbrains.kotlin.jvm)
-}
-java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
-}
-kotlin {
-    compilerOptions {
-        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
-    }
+    alias(libs.plugins.habits.jvm.library)
 }
 
 dependencies {

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -21,5 +21,9 @@ gradlePlugin {
             id = "habits.android.application.compose"
             implementationClass = "AndroidApplicationComposeConventionPlugin"
         }
+        register("jvmLibrary") {
+            id = "habits.jvm.library"
+            implementationClass = "JvmLibraryConventionPlugin"
+        }
     }
 }

--- a/build-logic/convention/src/main/java/JJvmLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/java/JJvmLibraryConventionPlugin.kt
@@ -1,0 +1,15 @@
+import com.roblesdotdev.convention.configureKotlinJvm
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+class JvmLibraryConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        target.run {
+            pluginManager.run {
+                apply("org.jetbrains.kotlin.jvm")
+            }
+            configureKotlinJvm()
+        }
+    }
+
+}

--- a/build-logic/convention/src/main/java/com/roblesdotdev/convention/Kotlin.kt
+++ b/build-logic/convention/src/main/java/com/roblesdotdev/convention/Kotlin.kt
@@ -3,6 +3,8 @@ package com.roblesdotdev.convention
 import com.android.build.api.dsl.CommonExtension
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
@@ -30,6 +32,14 @@ internal fun Project.configureKotlinAndroid(
     dependencies {
         "coreLibraryDesugaring"(libs.findLibrary("desugar-jdk-libs").get())
     }
+}
+
+internal fun Project.configureKotlinJvm() {
+    extensions.configure<JavaPluginExtension> {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    configureKotlin()
 }
 
 private fun Project.configureKotlin() {

--- a/core/domain/build.gradle.kts
+++ b/core/domain/build.gradle.kts
@@ -1,15 +1,5 @@
 plugins {
-    id("java-library")
-    alias(libs.plugins.jetbrains.kotlin.jvm)
-}
-java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
-}
-kotlin {
-    compilerOptions {
-        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
-    }
+    alias(libs.plugins.habits.jvm.library)
 }
 
 dependencies {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -82,3 +82,4 @@ kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", versi
 # Convention plugins
 habits-android-application = { id = "habits.android.application", version = "unespecified" }
 habits-android-application-compose = { id = "habits.android.application.compose", version = "unespecified" }
+habits-jvm-library = { id = "habits.jvm.library", version = "unespecified" }

--- a/habits/domain/build.gradle.kts
+++ b/habits/domain/build.gradle.kts
@@ -1,15 +1,5 @@
 plugins {
-    id("java-library")
-    alias(libs.plugins.jetbrains.kotlin.jvm)
-}
-java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
-}
-kotlin {
-    compilerOptions {
-        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
-    }
+    alias(libs.plugins.habits.jvm.library)
 }
 
 dependencies {

--- a/onboarding/domain/build.gradle.kts
+++ b/onboarding/domain/build.gradle.kts
@@ -1,15 +1,5 @@
 plugins {
-    id("java-library")
-    alias(libs.plugins.jetbrains.kotlin.jvm)
-}
-java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
-}
-kotlin {
-    compilerOptions {
-        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
-    }
+    alias(libs.plugins.habits.jvm.library)
 }
 
 dependencies {


### PR DESCRIPTION
This PR introduces a convention plugin for pure Kotlin/JVM modules, typically used in the **domain** layer or other non-Android, platform-agnostic components.

- Applies the `org.jetbrains.kotlin.jvm` plugin.
- Configures Kotlin compilation defaults via configureKotlinJvm() (assumed to set options like jvmTarget, etc.).