### PR TITLE
core: add android library convention plugin

### DIFF
--- a/auth/data/build.gradle.kts
+++ b/auth/data/build.gradle.kts
@@ -1,35 +1,9 @@
 plugins {
-    alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.habits.android.library)
 }
 
 android {
     namespace = "com.roblesdotdev.auth.data"
-    compileSdk = 35
-
-    defaultConfig {
-        minSdk = 24
-
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        consumerProguardFiles("consumer-rules.pro")
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
-            )
-        }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
-    }
-    kotlinOptions {
-        jvmTarget = "11"
-    }
 }
 
 dependencies {

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -21,6 +21,10 @@ gradlePlugin {
             id = "habits.android.application.compose"
             implementationClass = "AndroidApplicationComposeConventionPlugin"
         }
+        register("androidLibrary") {
+            id = "habits.android.library"
+            implementationClass = "AndroidLibraryConventionPlugin"
+        }
         register("jvmLibrary") {
             id = "habits.jvm.library"
             implementationClass = "JvmLibraryConventionPlugin"

--- a/build-logic/convention/src/main/java/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/java/AndroidLibraryConventionPlugin.kt
@@ -1,0 +1,38 @@
+import com.android.build.gradle.LibraryExtension
+import com.roblesdotdev.convention.ExtensionType
+import com.roblesdotdev.convention.configureBuildTypes
+import com.roblesdotdev.convention.configureKotlinAndroid
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.dependencies
+import org.gradle.kotlin.dsl.kotlin
+
+class AndroidLibraryConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        target.run {
+            pluginManager.run {
+                apply("com.android.library")
+                apply("org.jetbrains.kotlin.android")
+            }
+
+            extensions.configure<LibraryExtension> {
+                configureKotlinAndroid(this)
+
+                configureBuildTypes(
+                    commonExtension = this,
+                    extensionType = ExtensionType.LIBRARY
+                )
+
+                defaultConfig {
+                    testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+                    consumerProguardFiles("consumer-rules.pro")
+                }
+            }
+            dependencies {
+                "testImplementation"(kotlin("test"))
+            }
+        }
+    }
+
+}

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -1,35 +1,9 @@
 plugins {
-    alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.habits.android.library)
 }
 
 android {
     namespace = "com.roblesdotdev.core.data"
-    compileSdk = 35
-
-    defaultConfig {
-        minSdk = 24
-
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        consumerProguardFiles("consumer-rules.pro")
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
-            )
-        }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
-    }
-    kotlinOptions {
-        jvmTarget = "11"
-    }
 }
 
 dependencies {

--- a/core/database/build.gradle.kts
+++ b/core/database/build.gradle.kts
@@ -1,35 +1,9 @@
 plugins {
-    alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.habits.android.library)
 }
 
 android {
     namespace = "com.roblesdotdev.core.database"
-    compileSdk = 35
-
-    defaultConfig {
-        minSdk = 24
-
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        consumerProguardFiles("consumer-rules.pro")
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
-            )
-        }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
-    }
-    kotlinOptions {
-        jvmTarget = "11"
-    }
 }
 
 dependencies {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -83,3 +83,4 @@ kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", versi
 habits-android-application = { id = "habits.android.application", version = "unespecified" }
 habits-android-application-compose = { id = "habits.android.application.compose", version = "unespecified" }
 habits-jvm-library = { id = "habits.jvm.library", version = "unespecified" }
+habits-android-library = { id = "habits.android.library", version = "unespecified" }

--- a/habits/data/build.gradle.kts
+++ b/habits/data/build.gradle.kts
@@ -1,35 +1,9 @@
 plugins {
-    alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.habits.android.library)
 }
 
 android {
     namespace = "com.roblesdotdev.habits.data"
-    compileSdk = 35
-
-    defaultConfig {
-        minSdk = 24
-
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        consumerProguardFiles("consumer-rules.pro")
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
-            )
-        }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
-    }
-    kotlinOptions {
-        jvmTarget = "11"
-    }
 }
 
 dependencies {


### PR DESCRIPTION
This PR introduces a convention plugin to standardize the setup of Android library modules, particularly those used in the **data layer**. It promotes consistency, simplifies setup, and reduces repetitive configuration.

- Applies essential plugins:
  - `com.android.library`
  - `org.jetbrains.kotlin.android`
- Applies shared Kotlin and Android configuration