### PR TITLE
core: add android library compose convention plugin

### DIFF
--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -25,6 +25,10 @@ gradlePlugin {
             id = "habits.android.library"
             implementationClass = "AndroidLibraryConventionPlugin"
         }
+        register("androidLibraryCompose") {
+            id = "habits.android.library.compose"
+            implementationClass = "AndroidLibraryComposeConventionPlugin"
+        }
         register("jvmLibrary") {
             id = "habits.jvm.library"
             implementationClass = "JvmLibraryConventionPlugin"

--- a/build-logic/convention/src/main/java/AndroidLibraryComposeConventionPlugin.kt
+++ b/build-logic/convention/src/main/java/AndroidLibraryComposeConventionPlugin.kt
@@ -1,0 +1,18 @@
+import com.android.build.gradle.LibraryExtension
+import com.roblesdotdev.convention.configureAndroidCompose
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.getByType
+
+class AndroidLibraryComposeConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        target.run {
+            pluginManager.run {
+                apply("habits.android.library")
+            }
+
+            val extension = extensions.getByType<LibraryExtension>()
+            configureAndroidCompose(extension)
+        }
+    }
+}

--- a/core/presentation/designsystem/build.gradle.kts
+++ b/core/presentation/designsystem/build.gradle.kts
@@ -1,35 +1,9 @@
 plugins {
-    alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.habits.android.library.compose)
 }
 
 android {
     namespace = "com.roblesdotdev.core.presentation.designsystem"
-    compileSdk = 35
-
-    defaultConfig {
-        minSdk = 24
-
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        consumerProguardFiles("consumer-rules.pro")
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
-            )
-        }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
-    }
-    kotlinOptions {
-        jvmTarget = "11"
-    }
 }
 
 dependencies {

--- a/core/presentation/ui/build.gradle.kts
+++ b/core/presentation/ui/build.gradle.kts
@@ -1,35 +1,9 @@
 plugins {
-    alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.habits.android.library.compose)
 }
 
 android {
     namespace = "com.roblesdotdev.core.presentation.ui"
-    compileSdk = 35
-
-    defaultConfig {
-        minSdk = 24
-
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        consumerProguardFiles("consumer-rules.pro")
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
-            )
-        }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
-    }
-    kotlinOptions {
-        jvmTarget = "11"
-    }
 }
 
 dependencies {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -84,3 +84,4 @@ habits-android-application = { id = "habits.android.application", version = "une
 habits-android-application-compose = { id = "habits.android.application.compose", version = "unespecified" }
 habits-jvm-library = { id = "habits.jvm.library", version = "unespecified" }
 habits-android-library = { id = "habits.android.library", version = "unespecified" }
+habits-android-library-compose = { id = "habits.android.library.compose", version = "unespecified" }


### PR DESCRIPTION
This PR introduces a convention plugin tailored for library modules that use Jetpack Compose. It builds on top of the base `habits.android.library` convention and adds Compose-specific configuration.

- Applies the base library convention:
  - `template.android.library`
- Enables Jetpack Compose via `buildFeatures.compose = true`
- Adds required Compose dependencies:
  - Uses the Compose BOM to align versions across libraries
  -  Adds tooling dependencies for Preview support in debugImplementation

Designed for UI modules(**presentation**) in the library layer that rely on Jetpack Compose.
